### PR TITLE
Fixes bashrc line in installation

### DIFF
--- a/GPI_Install_Latest.sh
+++ b/GPI_Install_Latest.sh
@@ -170,7 +170,8 @@ then
     echo "To enable 'conda activate' (if you're using bash),"
     echo "add this line to the end of your .bashrc file:"
     echo " "
-    echo ". $MINICONDA_PATH/etc/profile.d/conda.sh"
+    # echo ". $MINICONDA_PATH/etc/profile.d/conda.sh"
+    echo "PATH=\"$MINICONDA_PATH/bin:\$PATH\""
     echo " "
     read -p "Would you like to do this now? [Y/n] " -n 1 -r APPEND_BASHRC
     echo

--- a/GPI_Install_Latest.sh
+++ b/GPI_Install_Latest.sh
@@ -47,7 +47,7 @@ while getopts "h32c:" opt; do
       ;;
     c)
       CHANNEL=$OPTARG
-      echo "Using channel $CHANNEL ." >&2 
+      echo "Using channel $CHANNEL ." >&2
       ;;
     h)
       help >&2
@@ -67,9 +67,9 @@ fi
 
 # check for root
 if [ "$(id -u)" == "0" ]; then
-    echo -n " 
+    echo -n "
     It looks like you are attempting to install GPI as root or sudo. While
-    this is possible, it is recommended that you install GPI under your 
+    this is possible, it is recommended that you install GPI under your
     home directory.
 
     Press ENTER to continue or CTRL-c to quit.
@@ -145,7 +145,7 @@ install ()
     $CONDA install -y gpi-core-nodes
 
     echo "Removing package files..."
-    $CONDA clean -t -i -p -l -y 
+    $CONDA clean -t -i -p -l -y
 
     # Clean up the downloaded files
     echo "Removing tmp files..."
@@ -172,12 +172,14 @@ then
     echo " "
     echo ". $MINICONDA_PATH/etc/profile.d/conda.sh"
     echo " "
-    read -p "Would you like to do this now? [Y/n]" -n 1 -r APPEND_BASHRC
+    read -p "Would you like to do this now? [Y/n] " -n 1 -r APPEND_BASHRC
     echo
     APPEND_BASHRC=${APPEND_BASHRC:-Y}
     if [[ $APPEND_BASHRC =~ ^[Yy]$ ]]
     then
-        echo ". $MINICONDA_PATH/etc/profile.d/conda.sh" >> ~/.bashrc
+        echo "# Added by GPI Installer" >> ~/.bashrc
+        echo "PATH=\"$MINICONDA_PATH/bin:\$PATH\"" >> ~/.bashrc
+        # echo ". $MINICONDA_PATH/etc/profile.d/conda.sh" >> ~/.bashrc
 	echo "Launch a new terminal for this to take effect."
     fi
     echo " "


### PR DESCRIPTION
Removed `echo ". $MINICONDA_PATH/etc/profile.d/conda.sh" >> ~/.bashrc` in favor of `echo "PATH=\"$MINICONDA_PATH/bin:\$PATH\"" >> ~/.bashrc` so that the conda `activate` script is available to the bash environment.